### PR TITLE
(fix): fix alias functions skipping 1st arg when passed one or more args

### DIFF
--- a/scripts-infra/setup_aliases.sh
+++ b/scripts-infra/setup_aliases.sh
@@ -66,9 +66,10 @@ function create_alias() {
 
         # Shift one here cos the 1st arg is the alias name of this alias func and we cant pass that
         # to docker-compose
-        shift 1;
+        # shift 1;
         # get the args that were passed to the alias and pass them as args to the alias function file
-        local args=$@
+        local args="$@"
+        # echo "internalAliasFunctionName -> '${internalAliasFunctionName}' args -> ${args}"
         source "'${fileName}'" ${args} & go_to_orig_dir;
         unset -f '${internalAliasFunctionName}';
     };


### PR DESCRIPTION
fix issue where the 1st arg that is passed to aliases is not processed by the alias
Signed-off-by: quophyie <quophyie@yahoo.com>